### PR TITLE
Added DarkRP_Hungermod setting to hudreplacement's hidden HUDs table

### DIFF
--- a/lua/darkrp_modules/hudreplacement/cl_hudreplacement.lua
+++ b/lua/darkrp_modules/hudreplacement/cl_hudreplacement.lua
@@ -16,8 +16,12 @@ local hideHUDElements = {
 
 	-- This is the one you're most likely to replace first
 	-- DarkRP_LocalPlayerHUD is the default HUD you see on the bottom left of the screen
-	-- It shows your health, job, salary and wallet
+	-- It shows your health, job, salary and wallet, but NOT hunger (if you have hungermod enabled)
 	["DarkRP_LocalPlayerHUD"] = false,
+
+	-- If you have hungermod enabled, you will see a hunger bar in the DarkRP_LocalPlayerHUD
+	-- This does not get disabled with DarkRP_LocalPlayerHUD so you will need to disable DarkRP_Hungermod too
+	["DarkRP_Hungermod"] = false,
 
 	-- Drawing the DarkRP agenda
 	["DarkRP_Agenda"] = false


### PR DESCRIPTION
This is perhaps why people are wondering how to disable the hunger bar with the rest of the DarkRP_LocalPlayerHUD.
