### PR TITLE
Ignore first commit. Got killed in the second commit. Documentation for weapon functions added. 

### DIFF
--- a/lua/darkrp_modules/weaponsettings/sh_weaponsettings.lua
+++ b/lua/darkrp_modules/weaponsettings/sh_weaponsettings.lua
@@ -50,6 +50,21 @@ SOME SETTINGS THAT CAN BE CHANGED USING THIS METHOD:
     - DefaultClip
 
 This list is not complete.
+A more complete list can be found at the following links(Note, not every variable is universal. Make sure to check documentation for the weapon you are modifiying!): 
+
+TFA Base:
+https://bitbucket.org/TheForgottenArchitect/tfa-base/src/463adebf0d55941361f7580d9eade151b658b7e1/lua/weapons/tfa_base_template/shared.lua?at=master&fileviewer=file-view-default
+
+M9K Base: 
+http://murderthon9000.com/bobs-base/
+
+CW 2.0: 
+https://docs.google.com/document/d/1FC6Lm7ml6eI-ocwSk5GXq5Sv0hZyrfQK9bMkChHhNNk/edit
+
+V92 SWEP Base: 
+http://steamcommunity.com/groups/CultOfV92/discussions/0/360671727314185116/
+
+Waiting on response from FA:S 2.0 Devs. 
 
 -- ADD WEAPON SETTINGS BELOW THIS LINE
 ]] -----------------------------------------

--- a/lua/darkrp_modules/weaponsettings/sh_weaponsettings.lua
+++ b/lua/darkrp_modules/weaponsettings/sh_weaponsettings.lua
@@ -10,14 +10,20 @@ This module allows you to change the settings of weapons. Here's how it works.
 Per weapon and setting a line is added in this format:
 weapon "WEAPON CLASS NAME HERE".SETTING_HERE = VALUE_HERE
 
+
+
 IMPORTANT:
     - Note the quotation marks around the weapon class name!
     - Note the '.' between the class name and the setting!
     - Casing MATTERS. PrintName IS NOT THE SAME AS printname!
     - CHANGING THE SETTINGS IS NOT RECODING THE WEAPON. PLEASE LEAVE THE AUTHORS FIELD INTACT. THANK YOU.
     - Technically you can set any field of the weapon. Advanced users can even override e.g. PrimaryAttack with this.
+	- This system is not limited to weapons that come with the DarkRP gamemode. 
 
 Examples:
+
+-- This essentially works by replacing "SWEP" at the start of each setting like "SWEP.Primary.Ammo = "pistol""
+with your customization in this file being "weapon_deagle2".Primary.Ammo = "ar2"
 
 -- Set the printname of the stunstick to "bash baton". Note: the quotation marks are important!
 weapon "stunstick".PrintName = "Bash baton"
@@ -31,11 +37,14 @@ weapon "weapon_p2282".Primary.Damage = 20
 
 LIST OF DEFAULT DARKRP WEAPONS:
 The class names of the default DarkRP weapons are listed on this page:
-https://github.com/FPtje/DarkRP/tree/master/entities/weapons
+https://github.com/FPtje/DarkRP/tree/master/entities/weapons 
 
-Note that it's the folder names that matter here, e.g. keys, med_kit, door_ram, weapon_m42 etc.
+You can find extra documentation for weapon functions here on this page: 
+https://github.com/FPtje/darkrpmodification/blob/master/lua/weapons/weapon_ak47custom/shared.lua
 
-SOME SETTINGS THAT CAN BE CHANGED USING THIS METHOD:
+Note that it's the folder names that matter here(the folders that contain the shared.lua for the weapons), e.g. keys, med_kit, door_ram, weapon_m42 etc.
+
+SOME EXAMPLE SETTINGS THAT CAN BE CHANGED USING THIS METHOD:
     - PrintName
     - Instructions
     - Contact
@@ -50,21 +59,6 @@ SOME SETTINGS THAT CAN BE CHANGED USING THIS METHOD:
     - DefaultClip
 
 This list is not complete.
-A more complete list can be found at the following links(Note, not every variable is universal. Make sure to check documentation for the weapon you are modifiying!): 
-
-TFA Base:
-https://bitbucket.org/TheForgottenArchitect/tfa-base/src/463adebf0d55941361f7580d9eade151b658b7e1/lua/weapons/tfa_base_template/shared.lua?at=master&fileviewer=file-view-default
-
-M9K Base: 
-http://murderthon9000.com/bobs-base/
-
-CW 2.0: 
-https://docs.google.com/document/d/1FC6Lm7ml6eI-ocwSk5GXq5Sv0hZyrfQK9bMkChHhNNk/edit
-
-V92 SWEP Base: 
-http://steamcommunity.com/groups/CultOfV92/discussions/0/360671727314185116/
-
-Waiting on response from FA:S 2.0 Devs. 
 
 -- ADD WEAPON SETTINGS BELOW THIS LINE
 ]] -----------------------------------------

--- a/lua/weapons/weapon_ak47custom/shared.lua
+++ b/lua/weapons/weapon_ak47custom/shared.lua
@@ -4,49 +4,57 @@ Here's an example weapon that you can edit
 AddCSLuaFile()
 
 if CLIENT then
-	SWEP.PrintName = "AK47"
-	SWEP.Author = "DarkRP Developers and <Name here>"
-	SWEP.Slot = 3
-	SWEP.SlotPos = 0
+	SWEP.PrintName = "AK47" -- The name that shows in the scroll menu and when you hover over the gun in the q-menu. 
+	SWEP.Author = "DarkRP Developers and <Name here>" -- Author Name. 
+	SWEP.Slot = 3 -- In which tab in the scroll menu the weapon shows up in. 1 being the far left and 9 being the farthest right. 
+	SWEP.SlotPos = 0 -- If you have 300 weapons all in the same slot you could organize each of them with a uniqe number all the way up to 300. Would keep it organized...I guess. 
 	SWEP.IconLetter = "b"
 
-	killicon.AddFont("weapon_ak47custom", "CSKillIcons", SWEP.IconLetter, Color(255, 80, 0, 255))
+	killicon.AddFont("weapon_ak47custom", "CSKillIcons", SWEP.IconLetter, Color(255, 80, 0, 255)) 
+	-- If you were to change the above folder name you would change the kill icon as well. 
+	
 end
 
-SWEP.Base = "weapon_cs_base2"
+SWEP.Base = "weapon_cs_base2" -- If you dont plan to use weapons from the workshop this wont matter much. 
 
-SWEP.Spawnable = true
-SWEP.AdminSpawnable = true
-SWEP.Category = "DarkRP (Weapon)"
+SWEP.Spawnable = true -- If the weapon can be spawned. 
+SWEP.AdminSpawnable = true -- If Admins can spawn this. 
+SWEP.Category = "DarkRP (Weapon)" -- Defines where the weapon will be grouped in the q-menu->weapons tab. Can be anything you like. (Case sensitive!) 
 SWEP.SpawnMenuIcon = "vgui/entities/weapon_ak472"
+-- For custom weapons you can create new icons by going to the materials folder of the addon and creating an entities folder
+-- and creating a png inside with the dimensions of 128x128 and have the name of the file match the name of the weapons folder name. 
+-- The above icon uses an older style of achieving the same goal. 
 
-SWEP.UseHands = true
-SWEP.ViewModel = "models/weapons/cstrike/c_rif_ak47.mdl"
-SWEP.WorldModel = "models/weapons/w_rif_ak47.mdl"
+SWEP.UseHands = true -- Use the hands of your playermodel if the playermodel supports it. 
+SWEP.ViewModel = "models/weapons/cstrike/c_rif_ak47.mdl" -- The players point of view. 
+SWEP.WorldModel = "models/weapons/w_rif_ak47.mdl" -- The point of view others have when looking at the player holding the gun. 
 
-SWEP.Weight = 5
-SWEP.AutoSwitchTo = false
-SWEP.AutoSwitchFrom = false
+SWEP.Weight = 5 
+SWEP.AutoSwitchTo = false -- When you pick it up should you auto switch to the gun? 
+SWEP.AutoSwitchFrom = false -- When you pick something else up should you switch away from what you are holding? 
 
-SWEP.HoldType = "ar2"
+SWEP.HoldType = "ar2" -- This is how others view you carrying the weapon. Options include:
+-- normal melee melee2 fist knife smg ar2 pistol rpg physgun grenade shotgun crossbow slam passive
+-- You're mostly going to use ar2, smg, shotgun or pistol. rpg and crossbow make for good sniper rifles
 
-SWEP.Primary.Sound = Sound("Weapon_AK47.Single")
-SWEP.Primary.Recoil = 1.5
-SWEP.Primary.Damage = 40
-SWEP.Primary.NumShots = 1
-SWEP.Primary.Cone = 0.002
-SWEP.Primary.ClipSize = 30
-SWEP.Primary.Delay = 0.08
-SWEP.Primary.DefaultClip = 30
-SWEP.Primary.Automatic = true
-SWEP.Primary.Ammo = "smg1"
+SWEP.Primary.Sound = Sound("Weapon_AK47.Single") -- The sound that is played while shooting. You can setup a sound file externally or you can paste the path to any type of sound file on your server.
+SWEP.Primary.Recoil = 1.5 -- How much the gun will jump while shooting.
+SWEP.Primary.Damage = 40 -- How much it will hurt every time a bullet hits its target. 
+SWEP.Primary.NumShots = 1 -- How many bullets come out every time you shoot. Anything higer than 1 would probably be a shotgun.
+SWEP.Primary.Cone = 0.002 -- How accurate the gun will be. Think "CSGO" when it comes to the weapon spread, thats this.
+SWEP.Primary.ClipSize = 30 -- How much ammo can you hold in the clip at one time. 
+SWEP.Primary.Delay = 0.08 -- A delay between shots. Effects fire speed. 
+SWEP.Primary.DefaultClip = 30 -- How much ammo you spawn with. 
+SWEP.Primary.Automatic = true -- Is the gun Semi-Automatic or Fully Automatic? True for Full; False for Semi. 
+SWEP.Primary.Ammo = "smg1" -- What kind of ammo.  Options, besides custom, include pistol, 357, smg1, ar2, buckshot, slam, SniperPenetratedRound, and AirboatGun.  
+--Pistol, buckshot, and slam like to ricochet. Use AirboatGun for a light metal peircing shotgun pellets
 
-SWEP.Secondary.ClipSize = -1
-SWEP.Secondary.DefaultClip = -1
-SWEP.Secondary.Automatic = false
-SWEP.Secondary.Ammo = "none"
+SWEP.Secondary.ClipSize = -1 -- How much ammo you have for your secondary fire. Since this weapon doesnt have a secondary fire its set to -1
+SWEP.Secondary.DefaultClip = -1 -- How much ammo you would spawn with for your secondary fire. 
+SWEP.Secondary.Automatic = false -- If your secondary fire is automatic or semi-automatic. 
+SWEP.Secondary.Ammo = "none" -- What type of ammo your secondary fire takes. If you dont have a secondary fire make sure to set this to none. 
 
-SWEP.IronSightsPos = Vector(-6.6, -15, 2.6)
-SWEP.IronSightsAng = Vector(2.6, 0.02, 0)
+SWEP.IronSightsPos = Vector(-6.6, -15, 2.6) -- Where the gun locks into place when aiming. 
+SWEP.IronSightsAng = Vector(2.6, 0.02, 0) -- Where the gun locks into place when aiming. 
 
 SWEP.MultiMode = true


### PR DESCRIPTION
sh_weaponsettings.lua
- Pointed out that the above is not limited to just the darkrp included weapons. 
- Referenced the example custom_ak47 as an example for functions. 
- Minor comment additions to a couple spots at the bottom. 

weapon_ak47custom/shared.lua
- Added comments to every function I recognized. 
- Missing comments for the  'SWEP.IconLetter = 'b'' and 'SWEP.MultiMode = true'