### PR TITLE
Add an option to edit "maxfooditems" limit

### DIFF
--- a/lua/darkrp_config/settings.lua
+++ b/lua/darkrp_config/settings.lua
@@ -212,6 +212,8 @@ GM.Config.maxdoors                      = 20
 GM.Config.maxdrugs                      = 2
 -- maxfoods - Sets the max food cartons per Microwave owner.
 GM.Config.maxfoods                      = 2
+-- maxfooditems - Sets the max amount of food items a player can buy from the F4 menu
+GM.Config.maxfooditems                  = 20
 -- maxlawboards - The maximum number of law boards the mayor can place.
 GM.Config.maxlawboards                  = 2
 -- maxletters - Sets max letters.


### PR DESCRIPTION
Added an option to edit the "maxfooditems" limit, because he does not exist.