### PR TITLE
can now disable only the FAdmin scoreboard.

### DIFF
--- a/lua/darkrp_config/disabled_defaults.lua
+++ b/lua/darkrp_config/disabled_defaults.lua
@@ -35,6 +35,7 @@ DarkRP.disabledDefaults["modules"] = {
 	["playerscale"]      = false,
 	["sleep"]            = false,
 	["fadmin"]           = false,
+	["scoreboard"]       = false, --set this to true if you want to disable the scoreboard and keep fadmin
 }
 
 


### PR DESCRIPTION
by changing DarkRP.disabledDefaults["modules"]["scoreboard"] to true, it's possible to remove only the FAdmin scoreboard