### PR TITLE
Weapon Checker's secondary attack text fix.

### DIFF
--- a/lua/darkrp_language/english.lua
+++ b/lua/darkrp_language/english.lua
@@ -231,7 +231,7 @@ local my_language = {
     no_weapons_confiscated = "%s had no weapons confiscated!",
     no_illegal_weapons = "%s had no illegal weapons.",
     confiscated_these_weapons = "Confiscated these weapons:",
-    checking_weapons = "Checking weapons",
+    checking_weapons = "Confiscating weapons",
 
     shipment_antispam_wait = "Please wait before spawning another shipment.",
     shipment_cannot_split = "Cannot split this shipment.",


### PR DESCRIPTION
Weapon checker shows this text only when we using secondary attack button.
If we will use primary attack button, then it will appear this text: «<Someone>'s illegal weapons: »