### PR TITLE
Update DarkRP wiki links

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ Everything you will need is in the Lua folder, because that is where the fun hap
 
 
 #### Check out the DarkRP wiki for guides, tutorials and documentation! ####
-[DarkRP Wiki](http://wiki.darkrp.com/index.php/Main_Page)
+[DarkRP Wiki](https://darkrp.miraheze.org/wiki/Main_Page)

--- a/addon.txt
+++ b/addon.txt
@@ -4,8 +4,8 @@
     "version"           "1"
     "up_date"           "00/00/00"
     "author_name"       "FPtje"
-    "author_email"      "wiki.darkrp.com"
-    "author_url"        "wiki.darkrp.com"
+    "author_email"      ""
+    "author_url"        "https://github.com/FPtje/DarkRP"
     "info"              "A mod with which you can modify DarkRP"
     "override"          "0"
 }

--- a/lua/darkrp_config/settings.lua
+++ b/lua/darkrp_config/settings.lua
@@ -316,7 +316,7 @@ GM.Config.lockdownsound = "npc/overwatch/cityvoice/f_confirmcivilstatus_1_spkr.w
 GM.Config.DarkRPSkin = "DarkRP"
 GM.Config.currency = "$"
 GM.Config.chatCommandPrefix = "/"
-GM.Config.F1MenuHelpPage = "https://wiki.darkrp.com/index.php/Main_Page"
+GM.Config.F1MenuHelpPage = "https://darkrp.miraheze.org/wiki/Main_Page"
 GM.Config.F1MenuHelpPageTitle = "DarkRP Wiki"
 
 -- Put Steam ID's and ranks in this list, and the players will have that rank when they join.

--- a/lua/darkrp_customthings/ammo.lua
+++ b/lua/darkrp_customthings/ammo.lua
@@ -17,7 +17,7 @@ ammoType: The name of the ammo that Garry's mod recognizes
    SWEP.Primary.Ammo = "AMMO NAME HERE"
    or
    SWEP.Secondary.Ammo = "AMMO NAME HERE"
-   You can find the default gmod ammo types here: https://wiki.garrysmod.com/page/Default_Ammo_Types
+   You can find the default gmod ammo types here: https://wiki.facepunch.com/gmod/Default_Ammo_Types
 
 name: The name you want to give to the ammo. This can be anything.
 

--- a/lua/darkrp_customthings/categories.lua
+++ b/lua/darkrp_customthings/categories.lua
@@ -4,7 +4,7 @@ Categories
 The categories of the default F4 menu.
 
 Please read this page for more information:
-http://wiki.darkrp.com/index.php/DarkRP:Categories
+https://darkrp.miraheze.org/wiki/DarkRP:Categories
 
 In case that page can't be reached, here's an example with explanation:
 

--- a/lua/darkrp_customthings/entities.lua
+++ b/lua/darkrp_customthings/entities.lua
@@ -9,10 +9,10 @@ Note: If you want to edit a default DarkRP entity, first disable it in darkrp_co
     Once you've done that, copy and paste the entity to this file and edit it.
 
 The default entities can be found here:
-https://github.com/FPtje/DarkRP/blob/master/gamemode/config/addentities.lua#L111
+https://github.com/FPtje/DarkRP/blob/master/gamemode/config/addentities.lua
 
 For examples and explanation please visit this wiki page:
-http://wiki.darkrp.com/index.php/DarkRP:CustomEntityFields
+https://darkrp.miraheze.org/wiki/DarkRP:CustomEntityFields
 
 Add entities under the following line:
 ---------------------------------------------------------------------------]]

--- a/lua/darkrp_customthings/jobs.lua
+++ b/lua/darkrp_customthings/jobs.lua
@@ -11,7 +11,7 @@ The default jobs can be found here:
 https://github.com/FPtje/DarkRP/blob/master/gamemode/config/jobrelated.lua
 
 For examples and explanation please visit this wiki page:
-http://wiki.darkrp.com/index.php/DarkRP:CustomJobFields
+https://darkrp.miraheze.org/wiki/DarkRP:CustomJobFields
 
 Add your custom jobs under the following line:
 ---------------------------------------------------------------------------]]

--- a/lua/darkrp_customthings/shipments.lua
+++ b/lua/darkrp_customthings/shipments.lua
@@ -12,7 +12,7 @@ The default shipments and guns can be found here:
 https://github.com/FPtje/DarkRP/blob/master/gamemode/config/addentities.lua
 
 For examples and explanation please visit this wiki page:
-http://wiki.darkrp.com/index.php/DarkRP:CustomShipmentFields
+https://darkrp.miraheze.org/wiki/DarkRP:CustomShipmentFields
 
 
 Add shipments and guns under the following line:

--- a/lua/darkrp_customthings/vehicles.lua
+++ b/lua/darkrp_customthings/vehicles.lua
@@ -6,7 +6,7 @@ This file contains your custom vehicles.
 This file should also contain vehicles from DarkRP that you edited.
 
 For examples and explanation please visit this wiki page:
-http://wiki.darkrp.com/index.php/DarkRP:Vehicles
+https://darkrp.miraheze.org/wiki/DarkRP:Vehicles
 
 If you want to keep the vehicle code and not comment it out you can add a vehicle to the "DarkRP.disabledDefaults["vehicles"]" section
 in the disabled_defaults.lua in the "darkrp_config" folder

--- a/lua/darkrp_modules/extraf4tab/cl_fancytab.lua
+++ b/lua/darkrp_modules/extraf4tab/cl_fancytab.lua
@@ -4,9 +4,8 @@ F4 menu tab modification module.
 
 if true then return end -- REMOVE THIS LINE TO ENABLE THIS MODULE
 
-local url = "http://wiki.darkrp.com/index.php/Main_Page"
+local url = "https://darkrp.miraheze.org/wiki/Main_Page"
 local tabName = "MOTD"
-
 
 local function createF4MenuTab()
     -- DarkRP.switchTabOrder(2, 3) -- Remove the "--" in this line if you want to move the third tab to the left of the second tab!

--- a/lua/darkrp_modules/how to make a module.txt
+++ b/lua/darkrp_modules/how to make a module.txt
@@ -28,10 +28,10 @@ lua/
 
 
 Here's a list of DarkRP functions that you can call in your module:
-http://wiki.darkrp.com/index.php/Category:Functions
+https://darkrp.miraheze.org/wiki/Category:Functions
 
 Here's a list of DarkRP hooks:
-http://wiki.darkrp.com/index.php/Category:Hooks
+https://darkrp.miraheze.org/wiki/Category:Hooks
 
 --[[---------------------------------------------------------------------------
 Autorefresh and simplerr


### PR DESCRIPTION
The old DarkRP wiki seems will be shutdown in July 31st.

R.I.P old wiki ❤️ 

**EDIT**:  I also updated the Gmod wiki link for [this file](https://github.com/FPtje/darkrpmodification/blob/08f96a8e32afff75fe32ff5d1eef131b85c273c4/lua/darkrp_customthings/ammo.lua#L20).